### PR TITLE
Modified Moses commit tag in requirements

### DIFF
--- a/dockers/requirements.txt
+++ b/dockers/requirements.txt
@@ -8,4 +8,4 @@ tqdm==4.26.0
 cython==0.29
 nltk==3.4.5
 flake8==3.5.0
-molsets @ git+https://github.com/molecularsets/moses.git@7b8f83b21a9b7ded493349ec8ef292384ce2bb52
+molsets @ git+https://github.com/molecularsets/moses.git@96c77d52c688dcac8e2962d78965175e7824c48c


### PR DESCRIPTION
This PR contains changes related to moses commit tag that was modified and pointing to an older version of moses now which is compatible with Guacamol Baselines.